### PR TITLE
Fix SPA routing fallback for client-side routes

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -315,6 +315,12 @@ export default {
     }
 
     // Serve static assets (React SPA)
-    return env.ASSETS.fetch(request);
+    // Try the requested path first; if not found, fall back to index.html
+    // so React Router can handle client-side routes like /upload
+    const response = await env.ASSETS.fetch(request);
+    if (response.status === 404 && !path.includes('.')) {
+      return env.ASSETS.fetch(new Request(new URL('/', request.url), request));
+    }
+    return response;
   },
 };


### PR DESCRIPTION
When visiting /upload or /artwork/:id directly, the Worker tried to find a matching static file which doesn't exist, returning a 404. Now falls back to serving index.html for non-file paths so React Router can handle client-side routing.

https://claude.ai/code/session_01GY2N2pDNYJpAPXfopZQQcK